### PR TITLE
Bugfix. Overview failing with other providers

### DIFF
--- a/nntp.go
+++ b/nntp.go
@@ -371,8 +371,11 @@ type MessageOverview struct {
 // begin and end, inclusive.
 func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 	if code, _, err := c.cmd(224, "OVER %d-%d", begin, end); err != nil {
-		// if error is "400 Unrecognized command" try the XOVER command
-		if code == 400 {
+		// if error is
+		// "400 Unrecognized command"
+		// "500 Unsupported."
+		// try the XOVER command
+		if code == 400 || code == 500 {
 			if _, _, err := c.cmd(224, "XOVER %d-%d", begin, end); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Hello,

Recently I tried using your NZB Monkey Go on UsenetFarm but it failed as the `OVER`-command returned me `500 Unsupported.` instead of the `400 Unrecognized command` you assume before trying `XOVER`.

FYI. RFC 3977 for NNTP (https://www.rfc-editor.org/rfc/rfc3977#section-8.3) dictates that for unknown commands the `500` responsecode should be used instead of `400`.

```Response code 500
Generic response
Meaning: unknown command.
```

Attached a minor change in your code to also interpret the `500` to try the `XOVER` command.